### PR TITLE
Works on macOS

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-clang test.c -L ./target/scala-2.13 -lfoo-out -lstdc++ -lm -lgcc -lgcc_s
+clang test.c -L ./target/scala-2.13 -lfoo-out -lstdc++ -lm
+


### PR DESCRIPTION
I was able to remove the `-lgcc*` links and it runs on macOS.

```sh
% ./a.out
% echo $?
0

```